### PR TITLE
Deploy script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 node_modules/
 build/
 
+client-*/
+*.pyc
+*.tgz

--- a/fabfile.py
+++ b/fabfile.py
@@ -1,0 +1,85 @@
+import os
+import sys
+from fabric.api import *
+from fabric.colors import red, yellow
+from fabric.contrib.console import confirm
+
+env.hosts = [os.getenv('HATCH_API_URL')]
+
+CODE_DIR = '/srv/hatch/client'
+
+@task
+def deploy(repo_uri=None):
+    """
+    Deploy latest version of Hatch client from master branch
+    """
+    if repo_uri is None:
+        repo_uri = 'git@github.com:dj/hatch.git'
+
+    tests()
+
+    git_hash = "git ls-remote -h {} master | awk '{{print $1;}}' | cut -c -7".format(repo_uri)
+    release_dir = '{}-`{}`'.format(CODE_DIR, git_hash)
+    if remote_dir_exists(release_dir):
+        msg = 'Latest hatch client already deployed!'
+        puts(red(msg, bold=True))
+        puts(red('Nothing to do', bold=True))
+        return
+
+    puts(yellow('removing any old local builds'))
+    with settings(warn_only=True):
+        local('rm archive-*.tgz')
+
+    create_artifact(tag=git_hash)
+
+    put('archive-*.tgz', '/srv/hatch/')
+
+    if remote_dir_exists(CODE_DIR):
+        puts(yellow('removing existing deploy symlink'))
+        run('rm {}'.format(CODE_DIR))
+
+    with cd('/srv/hatch'):
+        run('tar -xzf archive-*.tgz')
+        run('rm archive-*.tgz')
+
+    run('ln -s {} {}'.format(release_dir, CODE_DIR))
+    puts(yellow('restarting nginx for good measure'))
+    run('sudo service nginx restart')
+
+    if confirm('Cleanup local artifacts?'):
+        local('rm -rf client-*/')
+        local('rm archive-*.tgz')
+
+def tests():
+    # TODO update when tests working
+    puts(yellow('Running tests'))
+    with settings(warn_only=True):
+        tests = local('node_modules/.bin/mocha')
+    if tests.failed:
+        proceed = 'Tests ' + red('FAILED', bold=True) + '. Proceed anyways?'
+        if confirm(proceed):
+            msg = 'I accept that I am deploying code '\
+                  + red('without running tests') \
+                  + ' first.\nI also confirm that I have '\
+                  + red('MANUALLY VERIFIED', bold=True) + ' the code '\
+                  'I\'m about to deploy works.'
+            if not confirm(msg):
+                abort(red('Not proceeding'))
+        else:
+            abort(red('Not proceeding'))
+
+def remote_dir_exists(d):
+    with settings(warn_only=True):
+        return run('test -d {}'.format(d)).succeeded
+
+def create_artifact(tag=None):
+    local('node_modules/.bin/gulp build')
+    puts(yellow('preparing artifact'))
+    puts(yellow('fixing localhost redirect'))
+
+    local("sed -i '' 's/localhost:8080/dev.hatch.yacn.me/' build/js/bundle.js")
+    client_dir = 'client-`{}`'.format(tag)
+    archive = 'archive-`{}`.tgz'.format(tag)
+    local('mv build {}'.format(client_dir))
+    local('tar -cvzf {} {}'.format(archive, client_dir))
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,17 +11,29 @@ var less = require('gulp-less');
 var path = require('path');
 
 // Browserify
-var bundler = watchify(browserify('./src/js/main.js', watchify.args));
+var bundler = browserify('./src/js/main.js', watchify.args);
 bundler.transform('brfs'); // implements node's fs.readFileSync for browserify
 
+// Asset locations
+var not_tests = '!src/test/**';
+var html_files = 'src/**/*.html';
+var pngs = 'src/**/*.png'
+var files = [
+  not_tests,
+  html_files,
+  pngs
+]
+var libs = 'src/js/vendor/**/*';
+var fonts = 'src/fonts/**/*';
+var less_files = './src/less/**/*.less';
+
 // Tasks
-gulp.task('default', ['copy', 'vendor', 'fonts', 'less', 'less-watch', 'js']);
+gulp.task('default', ['watch']);
 gulp.task('js', bundle);
 gulp.task('copy', copyFiles);
 gulp.task('fonts', copyFonts);
 gulp.task('vendor', copyVendoredLibs);
-
-bundler.on('update', bundle); // on any dep update, runs the bundler
+gulp.task('build', ['copy', 'less', 'fonts', 'vendor', 'js'], function () { return;});
 
 function bundle() {
   return bundler.bundle()
@@ -35,7 +47,7 @@ function bundle() {
 }
 
 gulp.task('less', function() {
-  return gulp.src('./src/less/**/*.less')
+  return gulp.src(less_files)
     .pipe(less({
       paths: [
         'node_modules/bootstrap/less'
@@ -44,34 +56,28 @@ gulp.task('less', function() {
     .pipe(gulp.dest('./build/css'));
 })
 
-gulp.task('less-watch', ['less'], function() {
-  gulp.watch('./src/less/*.less', ['less']);
+gulp.task('watch', ['less', 'copy', 'vendor', 'fonts', 'js'], function () {
+  var watched_bundler = watchify(bundler);
+  watched_bundler.on('update', bundle); // on any dep update, runs the bundler
+
+  gulp.watch(less_files, ['less']);
+  gulp.watch(files, ['copy']);
+  gulp.watch(libs, ['vendor']);
+  gulp.watch(fonts, ['fonts']);
 });
 
 function copyFiles() {
-  var files = [
-    'src/**/*.html',
-    'src/**/*.png'
-  ]
-
   gulp.src(files)
-    .pipe(watch(files))
     .pipe(gulp.dest('build'));
 }
 
 function copyVendoredLibs() {
-  var libs = 'src/js/vendor/**/*';
-
   gulp.src(libs)
-    .pipe(watch(libs))
     .pipe(gulp.dest('build/js/vendor'));
 }
 
 function copyFonts() {
-  var fonts = 'src/fonts/**/*';
-
   gulp.src(fonts)
-    .pipe(watch(fonts))
     .pipe(gulp.dest('build/fonts'));
 }
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "hatch-client",
   "version": "0.0.0",
   "description": "Hatch - Client",
+  "repository": "https://github.com/dj/hatch",
   "dependencies": {
     "babyparse": "^0.4.1",
     "handlebars": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -19,11 +19,14 @@
     "gulp-sourcemaps": "^1.3.0",
     "gulp-util": "^3.0.3",
     "gulp-watch": "^4.1.1",
+    "mocha": "^2.2.4",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0"
   },
   "browserify": {
-    "transform": [ "browserify-shim" ]
+    "transform": [
+      "browserify-shim"
+    ]
   },
   "browserify-shim": {
     "jquery": "global:$",

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,12 @@
+var assert = require("assert")
+
+// Example Test
+describe('Array', function(){
+  describe('#indexOf()', function(){
+    it('should return -1 when the value is not present (example)', function(){
+      assert.equal(-1, [1,2,3].indexOf(5));
+      assert.equal(-1, [1,2,3].indexOf(0));
+    })
+  })
+})
+


### PR DESCRIPTION
Redux of previous pull request with updated gulpfile. Re-worked the gulpfile a bit, moved all the watching to a single task and a separate build task.

The script uses [Fabric](http://www.fabfile.org/) to deploy the latest code from the master branch to the staging server. You can install it via `pip install fabric`.

* Expects the environment variable `HATCH_API_URL` to determine where to deploy. This is available in chat. You'll also need to send me your SSH pub key before you'll be able to run the script.
* Assumes the dependencies/libraries are vendored in `node_modules` at the root of the repository.
* Tries to run tests locally before attempting to deploy (meaning, you must have `mocha` installed in your `node_modules` directory). If (when) they fail, you'll be prompted asking if you're sure you want to proceed etc.

Usage: `fab deploy`

Tested by using it to deploy the latest master branch to the staging server (which you can see as it now  has the modal window when authenticating to Twitter).
